### PR TITLE
catch the exception for a file that does not exist

### DIFF
--- a/src/Imagestyle.php
+++ b/src/Imagestyle.php
@@ -37,7 +37,11 @@ class Imagestyle
 
 	public function handle()
 	{
-		$data = Storage::disk($this->model->storage)->get($this->model->source);
+		try {
+			$data = Storage::disk($this->model->storage)->get($this->model->source);
+		} catch (\Illuminate\Contracts\Filesystem\FileNotFoundException $e) {
+			return null;
+		}
 		$this->img = ImageMaker::make($data);
 
 		foreach ($this->style['actions'] as $class=>$options)


### PR DESCRIPTION
Deze commit lost het probleem dat resulteerde in de HTTP 500 foutmelding van Sportbedrijf Rotterdam. 

Als ik het goed begreep van Bas, is het de bedoeling dat een niet-bestaande imagestyle (crop) automatisch wordt gegenereerd zodra deze niet gevonden kan worden. Dat kan ik echter niet vinden in deze code. Daarom graag review.