### PR TITLE
Return 404 when file isn't readable

### DIFF
--- a/src/Controllers/FrontendController.php
+++ b/src/Controllers/FrontendController.php
@@ -46,8 +46,11 @@ class FrontendController extends Controller
     {
         $media = Media::findOrFail($id);
 
-        $image = new Imagestyle($media, $imagestyle);
-
-        return $image->handle();
+        try {
+            $image = new Imagestyle($media, $imagestyle);
+            return $image->handle();
+        } catch (UnableToReadFile $e) {
+            abort(404);
+        }
     }
 }


### PR DESCRIPTION
Instead of failing with a 500 error the URL now returns a 404.